### PR TITLE
Allow passing receiver processing time range

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,10 @@ func Test_Main(t *testing.T) {
 		path string
 	}{
 		{
+			name: "receiver sleep",
+			path: "test/config-receiver-sleep.yaml",
+		},
+		{
 			name: "unordered",
 			path: "test/config.yaml",
 		},

--- a/receiver.go
+++ b/receiver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math/rand"
 	"time"
 
 	ce "github.com/cloudevents/sdk-go/v2"
@@ -37,6 +38,7 @@ func StartReceiver(ctx context.Context, config ReceiverConfig, received chan<- c
 	}()
 
 	err = client.StartReceiver(innerCtx, func(ctx context.Context, event ce.Event) {
+		maybeSleep(config)
 		received <- event
 	})
 	if err != nil {
@@ -51,4 +53,15 @@ func StartReceiver(ctx context.Context, config ReceiverConfig, received chan<- c
 	}
 
 	return nil
+}
+
+func maybeSleep(config ReceiverConfig) {
+	if config.ReceiverFaultConfig == nil || config.ReceiverFaultConfig.MinSleepDuration == nil {
+		return
+	}
+
+	max := *config.ReceiverFaultConfig.MaxSleepDuration
+	min := *config.ReceiverFaultConfig.MinSleepDuration
+
+	time.Sleep(min + time.Duration(rand.Int63n(int64(max-min))))
 }

--- a/test/config-receiver-sleep.yaml
+++ b/test/config-receiver-sleep.yaml
@@ -1,0 +1,14 @@
+sender:
+  target: http://localhost:34567
+  frequency: 10
+  workers: 1
+  keepAlive: true
+receiver:
+  port: 34567
+  timeout: 1m
+  maxDuplicatesPercentage: 0
+  fault:
+    minSleepDuration: 500ms
+    maxSleepDuration: 1s
+duration: 1m
+timeout: 1m


### PR DESCRIPTION
Receiver responding to events as quickly as possible isn't
realistic, this patch allows passing a time range to simulate
processing.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>