### PR TITLE
Log negative latency as warning message

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.17
+          go-version: ^1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/receiver.go
+++ b/receiver.go
@@ -76,9 +76,13 @@ func StartReceiver(ctx context.Context, config ReceiverConfig, received chan<- c
 			if err != nil {
 				panic(err)
 			}
-			start := time.Unix(t, 0)
+			start := time.UnixMilli(t)
 			latency := time.Since(start)
-			latencyHistogram.Record(ctx, latency.Milliseconds(), latencyHistogramLabels...)
+			if latency.Milliseconds() < 0 {
+				log.Printf("Negative latency %d\n", latency.Milliseconds())
+			} else {
+				latencyHistogram.Record(ctx, latency.Milliseconds(), latencyHistogramLabels...)
+			}
 		}
 
 		maybeSleep(config)


### PR DESCRIPTION
Time skew causes negative latencies, ignore those and log a warning
message.

Signed-off-by: Pierangelo Di Pilato <pierdipi@redhat.com>
